### PR TITLE
Additions to `CStrBuf`, TIME

### DIFF
--- a/n2o4/src/cfe/time.rs
+++ b/n2o4/src/cfe/time.rs
@@ -4,27 +4,116 @@
 //! Time Services system.
 
 use cfs_sys::*;
+use core::cmp::Ordering;
+use core::ops::{Add, Sub};
 
-/// A system time value, represented as seconds since some epoch.
-///
-/// Wraps `CFE_TIME_SysTime_t`.
-#[doc(alias = "CFE_TIME_SysTime_t")]
-#[derive(Clone, Copy, Debug)]
-pub struct SysTime {
-    pub(crate) tm: CFE_TIME_SysTime_t,
+macro_rules! cfe_time_type {
+    ($name:ident : $type_docstring:literal, $accessor_docstring:literal) => {
+        #[doc = $type_docstring]
+        ///
+        /// Wraps `CFE_TIME_SysTime_t`.
+        #[doc(alias = "CFE_TIME_SysTime_t")]
+        #[derive(Clone, Copy, Debug)]
+        pub struct $name {
+            pub(crate) tm: CFE_TIME_SysTime_t,
+        }
+
+        impl $name {
+            #[doc = concat!("Creates a new `", stringify!($name), "` with the specified seconds/subseconds count.")]
+            #[inline]
+            pub const fn new(seconds: u32, subseconds: u32) -> Self {
+                Self { tm: CFE_TIME_SysTime_t { Seconds: seconds, Subseconds: subseconds } }
+            }
+
+            #[doc = concat!("Returns the number of whole seconds ", $accessor_docstring, ".")]
+            #[inline]
+            pub const fn seconds(self) -> u32 {
+                self.tm.Seconds
+            }
+
+            #[doc = concat!("Returns the fractional number of seconds ", $accessor_docstring)]
+            /// (in units of 2<sup>&#8722;32</sup>&nbsp;seconds).
+            #[inline]
+            pub const fn subseconds(self) -> u32 {
+                self.tm.Subseconds
+            }
+        }
+
+        /// Wraps `CFE_TIME_Compare`.
+        impl PartialEq for $name {
+            #[doc(alias = "CFE_TIME_Compare")]
+            #[inline]
+            fn eq(&self, other: &Self) -> bool {
+                cfs_sys::CFE_TIME_Compare_CFE_TIME_EQUAL == unsafe { CFE_TIME_Compare(self.tm, other.tm) }
+            }
+        }
+
+        impl Eq for $name {}
+
+        /// Wraps `CFE_TIME_Compare`.
+        impl Ord for $name {
+            #[doc(alias = "CFE_TIME_Compare")]
+            #[inline]
+            fn cmp(&self, other: &Self) -> Ordering {
+                match unsafe { CFE_TIME_Compare(self.tm, other.tm) } {
+                    cfs_sys::CFE_TIME_Compare_CFE_TIME_A_LT_B => Ordering::Less,
+                    cfs_sys::CFE_TIME_Compare_CFE_TIME_EQUAL => Ordering::Equal,
+                    _ => Ordering::Greater,
+                }
+            }
+        }
+
+        /// Wraps `CFE_TIME_Compare`.
+        impl PartialOrd for $name {
+            #[doc(alias = "CFE_TIME_Compare")]
+            #[inline]
+            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+    };
 }
 
-impl SysTime {
-    /// Returns the number of whole seconds since the relevant epoch.
-    pub const fn seconds(self) -> u32 {
-        self.tm.Seconds
-    }
+cfe_time_type!(SysTime:
+    "A system time value, represented as seconds/subseconds since some epoch.",
+    "since the relevant epoch"
+);
+cfe_time_type!(DeltaTime:
+    "An increment in time, represented in seconds/subseconds.",
+    "in the time delta"
+);
 
-    /// Returns the fractional number of seconds since the relevant epoch
-    /// (in units of 2<sup>&#8722;32</sup>&nbsp;seconds).
-    pub const fn subseconds(self) -> u32 {
-        self.tm.Subseconds
-    }
+macro_rules! cfe_time_op {
+    ($trait:ident $method:ident $wrapped:ident $wrapped_str:literal : $($lhs:ty , $rhs:ty => $output:ty),*) => {
+        $(
+            #[doc = concat!("Wraps `", stringify!($wrapped), "`.")]
+            impl $trait<$rhs> for $lhs {
+                type Output = $output;
+
+                #[doc(alias = $wrapped_str)]
+                #[inline]
+                fn $method(self, rhs: $rhs) -> $output {
+                    Self::Output { tm: unsafe { $wrapped(self.tm, rhs.tm) } }
+                }
+            }
+        )*
+    };
+}
+
+#[rustfmt::skip]
+cfe_time_op! {
+    Add add CFE_TIME_Add "CFE_TIME_Add" :
+    SysTime   , DeltaTime => SysTime,
+    DeltaTime , SysTime   => SysTime,
+    DeltaTime , DeltaTime => DeltaTime
+}
+
+#[rustfmt::skip]
+cfe_time_op! {
+    Sub sub CFE_TIME_Subtract "CFE_TIME_Subtract" :
+    SysTime   , SysTime   => DeltaTime,
+    SysTime   , DeltaTime => SysTime,
+    DeltaTime , DeltaTime => DeltaTime
 }
 
 /// Returns the current spacecraft time,

--- a/n2o4/src/utils.rs
+++ b/n2o4/src/utils.rs
@@ -123,6 +123,24 @@ impl<const SIZE: usize> CStrBuf<SIZE> {
         Self { buf }
     }
 
+    /// Creates a new `CStrBuf<SIZE>` using `src`.
+    ///
+    /// `src` is modified to ensure null-termination.
+    ///
+    /// # Panics
+    ///
+    /// Panics if and only if `SIZE` is `0`.
+    #[inline]
+    pub const fn new_into(src: [c_char; SIZE]) -> Self {
+        if SIZE == 0 {
+            panic!("CStrBuf instances of length 0 not allowed")
+        }
+
+        let mut src = src;
+        src[SIZE - 1] = b'\0' as c_char;
+        Self { buf: src }
+    }
+
     /// Returns a pointer to the start of the string.
     #[inline]
     pub const fn as_ptr(&self) -> *const c_char {


### PR DESCRIPTION
This PR includes three additions:

* A consuming constructor for `CStrBuf`
* Splitting the "absolute time" and "time delta" roles of `cfe::time::SysTime` into separate types (`SysTime` and `DeltaTime`, respectively)
* Implementing operations on `SysTime` and `DeltaTime`

The latter two are of use for current development of an internal app; the first should be useful for some future bindings work.