### PR TITLE
Changed `AsRef<CStr>` type bound to `AsRef<CStr> + ?Sized`

### DIFF
--- a/n2o4/src/cfe/es.rs
+++ b/n2o4/src/cfe/es.rs
@@ -261,7 +261,7 @@ pub fn restart_app(app_id: AppId) -> Result<(), Status> {
 /// Wraps `CFE_ES_ReloadApp`.
 #[doc(alias = "CFE_ES_ReloadApp")]
 #[inline]
-pub fn reload_app<S: AsRef<CStr>>(app_id: AppId, app_file_name: &S) -> Result<(), Status> {
+pub fn reload_app<S: AsRef<CStr> + ?Sized>(app_id: AppId, app_file_name: &S) -> Result<(), Status> {
     let s: Status = unsafe { CFE_ES_ReloadApp(app_id.id, app_file_name.as_ref().as_ptr()) }.into();
     s.as_result(|| ())
 }

--- a/n2o4/src/cfe/sb.rs
+++ b/n2o4/src/cfe/sb.rs
@@ -212,7 +212,7 @@ impl Pipe {
     /// Wraps `CFE_SB_CreatePipe`.
     #[doc(alias = "CFG_SB_CreatePipe")]
     #[inline]
-    pub fn new<S: AsRef<CStr>>(depth: u16, pipe_name: &S) -> Result<Pipe, Status> {
+    pub fn new<S: AsRef<CStr> + ?Sized>(depth: u16, pipe_name: &S) -> Result<Pipe, Status> {
         let mut p: CFE_SB_PipeId_t = super::ResourceId::UNDEFINED.id;
 
         let s: Status =

--- a/n2o4/src/cfe/tbl.rs
+++ b/n2o4/src/cfe/tbl.rs
@@ -23,7 +23,7 @@ impl<T: Copy + Sync + Sized + 'static> TableType for T {}
 /// Wraps `CFE_TBL_GetInfo`.
 #[doc(alias = "CFE_TBL_GetInfo")]
 #[inline]
-pub fn info<S: AsRef<CStr>>(table_name: &S) -> Result<TblInfo, Status> {
+pub fn info<S: AsRef<CStr> + ?Sized>(table_name: &S) -> Result<TblInfo, Status> {
     let mut info: CFE_TBL_Info_t = DEFAULT_TBL_INFO;
 
     let status: Status = unsafe { CFE_TBL_GetInfo(&mut info, table_name.as_ref().as_ptr()) }.into();
@@ -47,7 +47,7 @@ impl<T: TableType> TblHandle<T> {
     /// Wraps `CFE_TBL_Register`.
     #[doc(alias = "CFE_TBL_Register")]
     #[inline]
-    pub fn register<S: AsRef<CStr>>(
+    pub fn register<S: AsRef<CStr> + ?Sized>(
         tbl_name: &S,
         options: TblOptions,
         validation_fn: Option<TableValidationFn<T>>,
@@ -326,7 +326,7 @@ impl<T: TableType> DumpOnlyTblHandle<T> {
     /// (and for tables with a user-defined address, `CFE_TBL_Load`).
     #[doc(alias("CFE_TBL_Register", "CFE_TBL_Load"))]
     #[inline]
-    pub fn register<S: AsRef<CStr>>(
+    pub fn register<S: AsRef<CStr> + ?Sized>(
         tbl_name: &S,
         tbl_buffer: Option<&'static mut T>,
         validation_fn: Option<TableValidationFn<T>>,
@@ -502,7 +502,7 @@ impl<T: TableType> SharedTblHandle<T> {
     /// is; this fact must be verified by the programmer.
     #[doc(alias = "CFE_TBL_Share")]
     #[inline]
-    pub unsafe fn share<S: AsRef<CStr>>(tbl_name: &S) -> Result<Self, Status> {
+    pub unsafe fn share<S: AsRef<CStr> + ?Sized>(tbl_name: &S) -> Result<Self, Status> {
         let mut hdl: CFE_TBL_Handle_t = X_CFE_TBL_BAD_TABLE_HANDLE;
 
         let status: Status = CFE_TBL_Share(&mut hdl, tbl_name.as_ref().as_ptr()).into();

--- a/n2o4/src/osal/file.rs
+++ b/n2o4/src/osal/file.rs
@@ -25,7 +25,7 @@ impl File {
     /// Wraps `OS_OpenCreate`.
     #[doc(alias = "OS_OpenCreate")]
     #[inline]
-    pub fn open_create<S: AsRef<CStr>>(
+    pub fn open_create<S: AsRef<CStr> + ?Sized>(
         path: &S,
         flags: FileFlags,
         access_mode: AccessMode,
@@ -142,7 +142,7 @@ impl OwnedFile {
     /// Like [`File::open_create`], but returning an [`OwnedFile`] on success instead.
     #[doc(alias = "OS_OpenCreate")]
     #[inline]
-    pub fn open_create<S: AsRef<CStr>>(
+    pub fn open_create<S: AsRef<CStr> + ?Sized>(
         path: &S,
         flags: FileFlags,
         access_mode: AccessMode,


### PR DESCRIPTION
In the places we're using `S: AsRef<CStr>`, we only ever deal with references to `S`.

The implicit `Sized` bound is thus unnecessarily restrictive (and in some contexts, actively obstructive), so this PR removes it.