### PR TITLE
Addition of binding for CFE_ES_ResetCFE; some minor fixes

### DIFF
--- a/n2o4/src/cfe/es.rs
+++ b/n2o4/src/cfe/es.rs
@@ -85,6 +85,20 @@ pub enum SystemState {
     Shutdown    = CFE_ES_SystemState_CFE_ES_SystemState_SHUTDOWN,
 }
 
+/// The type of cFE system reset desired in a call to [`reset_cfe`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u32)]
+pub enum ResetType {
+    /// A reset that causes all memory to be cleared.
+    #[doc(alias = "CFE_PSP_RST_TYPE_POWERON")]
+    PowerOn   = CFE_PSP_RST_TYPE_POWERON,
+
+    /// A reset that attempts to retain volatile disk, critical data store,
+    /// and user reserved memory.
+    #[doc(alias = "CFE_PSP_RST_TYPE_PROCESSOR")]
+    Processor = CFE_PSP_RST_TYPE_PROCESSOR,
+}
+
 /// Logs an entry/exit marker for a specified ID
 /// for use by
 /// [the Software Performance Analysis tool](https://github.com/nasa/perfutils-java).
@@ -169,6 +183,19 @@ pub fn write_to_syslog_str(msg: &str) -> Status {
         CFE_ES_WriteToSysLog(super::RUST_STR_FMT.as_ptr(), msg.len(), msg.as_ptr() as *const c_char)
     }
     .into()
+}
+
+/// Immediately resets the cFE core and all cFE applications.
+///
+/// Wraps `CFE_ES_ResetCFE`.
+#[doc(alias = "CFE_ES_ResetCFE")]
+#[inline]
+pub fn reset_cfe(reset_type: ResetType) -> Result<crate::utils::Unconstructable, Status> {
+    let reset_type = reset_type as u32;
+
+    // Upon success, CFE_ES_ResetCFE doesn't return, so any return value
+    // is an error:
+    Err(unsafe { CFE_ES_ResetCFE(reset_type) }.into())
 }
 
 /// Exits from the current application.

--- a/n2o4/src/cfe/es.rs
+++ b/n2o4/src/cfe/es.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 The Pennsylvania State University and the project contributors.
+// Copyright (c) 2021-2023 The Pennsylvania State University and the project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Executive Services system.
@@ -13,6 +13,7 @@ use printf_wrap::{PrintfArgument, PrintfFmt};
 #[doc(alias = "CFE_ES_RunStatus")]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum RunStatus {
     /// Application is exiting with an error.
     #[doc(alias = "CFE_ES_RunStatus_APP_ERROR")]
@@ -59,6 +60,7 @@ pub enum RunStatus {
 #[doc(alias = "CFE_ES_SystemState")]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum SystemState {
     /// Single-threaded mode while setting up CFE itself.
     #[doc(alias = "CFE_ES_SystemState_EARLY_INIT")]
@@ -88,6 +90,7 @@ pub enum SystemState {
 /// The type of cFE system reset desired in a call to [`reset_cfe`].
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum ResetType {
     /// A reset that causes all memory to be cleared.
     #[doc(alias = "CFE_PSP_RST_TYPE_POWERON")]

--- a/n2o4/src/cfe/evs.rs
+++ b/n2o4/src/cfe/evs.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 The Pennsylvania State University and the project contributors.
+// Copyright (c) 2021-2023 The Pennsylvania State University and the project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Event system.
@@ -131,6 +131,7 @@ pub fn register<T: FilterScheme>(filters: &[T]) -> Result<EventSender, Status> {
 #[doc(alias = "CFE_EVS_EventType")]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u16)]
+#[non_exhaustive]
 pub enum EventType {
     /// Events that are intended only for debugging, not nominal operations.
     #[doc(alias = "CFE_EVS_EventType_DEBUG")]

--- a/n2o4/src/cfe/msg.rs
+++ b/n2o4/src/cfe/msg.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 The Pennsylvania State University and the project contributors.
+// Copyright (c) 2021-2023 The Pennsylvania State University and the project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Message utilities.
@@ -487,6 +487,7 @@ impl<T: Copy> DerefMut for Telemetry<T> {
 #[doc(alias = "CFG_MSG_Type")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum MsgType {
     /// Command message.
     #[doc(alias = "CFG_MSG_Type_Cmd")]

--- a/n2o4/src/cfe/sb.rs
+++ b/n2o4/src/cfe/sb.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 The Pennsylvania State University and the project contributors.
+// Copyright (c) 2021-2023 The Pennsylvania State University and the project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Software Bus system.
@@ -98,6 +98,7 @@ impl From<MsgId> for MsgId_Atom {
 #[doc(alias = "CFG_SB_QosPriority")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum QosPriority {
     /// High priority.
     #[doc(alias = "CFG_SB_QosPriority_HIGH")]
@@ -112,6 +113,7 @@ pub enum QosPriority {
 #[doc(alias = "CFG_SB_QosReliability")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum QosReliability {
     /// High reliability.
     #[doc(alias = "CFG_SB_QosReliability_HIGH")]

--- a/n2o4/src/cfe/tbl.rs
+++ b/n2o4/src/cfe/tbl.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 The Pennsylvania State University and the project contributors.
+// Copyright (c) 2021-2023 The Pennsylvania State University and the project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Table system.
@@ -544,6 +544,7 @@ impl<T: TableType> Drop for SharedTblHandle<T> {
 
 /// Alternative successful or partially-successful outcomes of [`TblHandle::register`].
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[non_exhaustive]
 pub enum RegisterInfo {
     /// Normal successful registration.
     Normal,
@@ -582,6 +583,7 @@ impl Default for TblOptions {
 /// Options regarding buffer use on table modifications.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u16)]
+#[non_exhaustive]
 pub enum TblBuffering {
     /// Modifications to the table will use a shared memory space,
     /// copying to the actual table buffer when the table update occurs.
@@ -608,6 +610,7 @@ pub enum TblBuffering {
 /// stored in the Critical Data Store (CDS).
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u16)]
+#[non_exhaustive]
 pub enum TblCriticality {
     /// Not critical; no copy of the table will be stored in the CDS.
     ///
@@ -635,6 +638,7 @@ pub enum TblLoadSource<'a, T> {
 
 /// A pending action for a table.
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub enum PendingAction {
     /// An update is pending.
     Update,

--- a/n2o4/src/osal/file.rs
+++ b/n2o4/src/osal/file.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 The Pennsylvania State University and the project contributors.
+// Copyright (c) 2022-2023 The Pennsylvania State University and the project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Types and methods for interacting with files.
@@ -197,6 +197,7 @@ impl From<OwnedFile> for File {
 /// Used with [`File::open_create`].
 #[repr(i32)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[non_exhaustive]
 pub enum AccessMode {
     /// Read-only access.
     ///
@@ -275,6 +276,7 @@ impl BitOrAssign for FileFlags {
 /// Used as the `whence` argument of [`File::lseek`].
 #[repr(u32)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[non_exhaustive]
 pub enum SeekReference {
     /// Seek from the beginning of the file.
     ///

--- a/n2o4/src/osal/socket.rs
+++ b/n2o4/src/osal/socket.rs
@@ -695,6 +695,7 @@ impl<D: SocketDomain, T: SocketType, R: SocketRole> PartialEq<Self> for Socket<D
 #[doc(alias = "OS_SocketShutdownMode_t")]
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
+#[non_exhaustive]
 pub enum SocketShutdownMode {
     /// Shut down the read direction of the session.
     #[doc(alias = "OS_SocketShutdownMode_SHUT_READ")]

--- a/n2o4/src/osal/sync.rs
+++ b/n2o4/src/osal/sync.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 The Pennsylvania State University and the project contributors.
+// Copyright (c) 2022-2023 The Pennsylvania State University and the project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
 //! Synchronization primitives.
@@ -171,6 +171,7 @@ impl TryFrom<ObjectId> for BinSem {
 /// The initial state of a semaphore.
 #[repr(u32)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[non_exhaustive]
 pub enum BinSemState {
     /// Full state.
     Full  = OS_SEM_FULL,

--- a/n2o4/src/utils.rs
+++ b/n2o4/src/utils.rs
@@ -83,7 +83,7 @@ impl TryFrom<i32> for NegativeI32 {
 
 /// An owned null-terminated C-compatible string of at most `SIZE` bytes
 /// (including null terminator).
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct CStrBuf<const SIZE: usize> {
     buf: [c_char; SIZE],
 }
@@ -194,6 +194,18 @@ impl<const SIZE: usize> AsRef<CStr> for CStrBuf<SIZE> {
         unsafe { CStr::from_ptr(self.buf.as_ptr()) }
     }
 }
+
+impl<const SIZE: usize, const OTHER: usize> PartialEq<CStrBuf<OTHER>> for CStrBuf<SIZE> {
+    #[inline]
+    fn eq(&self, other: &CStrBuf<OTHER>) -> bool {
+        let s: &CStr = self.as_ref();
+        let o: &CStr = other.as_ref();
+
+        *s == *o
+    }
+}
+
+impl<const SIZE: usize> Eq for CStrBuf<SIZE> {}
 
 /// A way to get the `Atomic*` type associated with a given integer type.
 pub(crate) trait AtomicVersion {


### PR DESCRIPTION
Said minor fixes are fixing the `PartialEq` implementation for `CStrBuf` and marking `enum`s that mirror cFE/OSAL enumerations `#[non_exhaustive]`.