### PR TITLE
Potpourri

### DIFF
--- a/n2o4/src/cfe/es.rs
+++ b/n2o4/src/cfe/es.rs
@@ -490,7 +490,6 @@ pub fn create_child_task<F: FnOnce() + Send + Sized + 'static, S: AsRef<CStr> + 
         .map_err(|_| Status::STATUS_EXTERNAL_RESOURCE_FAIL)?;
 
     s.as_result(|| ())?;
-    core::mem::drop(fptr);
 
     if task_id.id == X_CFE_RESOURCEID_UNDEFINED {
         return Err(Status::ES_ERR_RESOURCEID_NOT_VALID);

--- a/n2o4/src/cfe/msg.rs
+++ b/n2o4/src/cfe/msg.rs
@@ -331,6 +331,12 @@ impl<T: Copy + Sized> Command<T> {
 
         cmd.set_fcn_code(fcn_code)?;
 
+        // Set the payload again, as it might have gotten nuked by one of the API calls.
+        // Safe due to payload being Copy.
+        unsafe {
+            core::ptr::write(core::ptr::addr_of_mut!(cmd.payload), payload);
+        }
+
         Ok(cmd)
     }
 }
@@ -427,6 +433,12 @@ impl<T: Copy + Sized> Telemetry<T> {
         }
 
         unsafe { Message::from_cfe_mut(&mut tlm.header.Msg).init(msg_id, sz) }?;
+
+        // Set the payload again, as it might have gotten nuked by the API calls.
+        // Safe due to payload being Copy.
+        unsafe {
+            core::ptr::write(core::ptr::addr_of_mut!(tlm.payload), payload);
+        }
 
         Ok(tlm)
     }

--- a/n2o4/src/cfe/tbl.rs
+++ b/n2o4/src/cfe/tbl.rs
@@ -115,8 +115,6 @@ impl<T: TableType> TblHandle<T> {
             Some(tbl_ref) => Ok(closure(tbl_ref, updated_recently)),
         };
 
-        drop(tbl_ptr);
-
         let _ = unsafe { CFE_TBL_ReleaseAddress(self.hdl) };
 
         return_val
@@ -380,7 +378,6 @@ impl<T: TableType> DumpOnlyTblHandle<T> {
             }
             .into();
 
-            drop(buf_ptr);
             s.as_result(|| ())?;
         }
 

--- a/n2o4/src/utils.rs
+++ b/n2o4/src/utils.rs
@@ -204,6 +204,12 @@ impl<const SIZE: usize> CStrBuf<SIZE> {
     pub const fn as_ptr(&self) -> *const c_char {
         self.buf.as_ptr()
     }
+
+    /// Returns a reference to the underlying array.
+    #[inline]
+    pub const fn as_array(&self) -> &[c_char; SIZE] {
+        &self.buf
+    }
 }
 
 impl<const SIZE: usize> Deref for CStrBuf<SIZE> {

--- a/n2o4/src/utils.rs
+++ b/n2o4/src/utils.rs
@@ -124,6 +124,33 @@ impl<const SIZE: usize> CStrBuf<SIZE> {
         Self { buf }
     }
 
+    /// Creates a new `CStrBuf<SIZE>` from `src`, handling conversion from [`u8`] to [`c_char`];
+    /// if `src` is longer than `SIZE - 1` bytes,
+    /// only the first `SIZE - 1` bytes of `src`
+    /// are copied over.
+    ///
+    /// # Panics
+    ///
+    /// Panics if and only if `SIZE` is `0`.
+    #[inline]
+    pub const fn new_u8(src: &[u8]) -> Self {
+        if SIZE == 0 {
+            panic!("CStrBuf instances of length 0 not allowed");
+        }
+
+        let mut buf = [b'\0' as c_char; SIZE];
+
+        let copy_len = min(src.len(), SIZE - 1);
+
+        let mut i = 0usize;
+        while i < copy_len {
+            buf[i] = src[i] as c_char;
+            i += 1;
+        }
+
+        Self { buf }
+    }
+
     /// Creates a new `CStrBuf<SIZE>` using `src`.
     ///
     /// `src` is modified to ensure null-termination.


### PR DESCRIPTION
This pull request has a few additions in `CBufStr` and the CMake files for easier use, a couple of bugfixes in `n2o4::cfe::msg`, and some clearing out of superfluous uses of `drop()`.