### PR TITLE
gh-pages: Flushing out index page; FSW 2023 presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,19 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>n2o4 Rustdocs</title>
+  <title>n2o4: Rustdocs and other useful links</title>
 </head>
 <body>
-  <p><a href="main/n2o4">main</a></p>
+  <h1><tt>n2o4</tt>: Rust for Core Flight System applications</h1>
+
+  <h2>Rustdocs</h2>
+  <ul>
+    <li><a href="main/n2o4">current main</a></li>
+  </ul>
+
+  <h2>Presentations</h2>
+  <ul>
+    <li>&quot;cFS Applications in Rust with <tt>n2o4</tt>&quot;. Presented at the <a href="https://flightsoftware.org/workshop/FSW2023">16th Annual Workshop on Spacecraft Flight Software</a> (FSW 2023), Pasadena, CA, USA, March 2023. <a href="fsw2023-n2o4.pdf">slides</a> <a href="https://www.youtube.com/live/H7q-7CNb7gc?si=zgWjLlaCxNHJfRJq&t=8229">video</a></li>
+  </ul>
 </body>
 </html>


### PR DESCRIPTION
This merge request improves `gh-pages` by

* adding some structure to the top-level index page, rather than just showing a somewhat cryptic link
* adding the slide deck from my FSW 2023 presentation for public consumption